### PR TITLE
Fix selection / highlighting of HTML completions

### DIFF
--- a/js/typeahead.fb.js
+++ b/js/typeahead.fb.js
@@ -246,7 +246,7 @@
 			name 	: name,
 			limit 	: 10000, // hack to display all returned data
 			source 	: source,
-			display : displayVal,
+			display : 'value',
 			templates : _renderSetTemplate(set)
 		};
 


### PR DESCRIPTION
When using `displayVal` for the `display` property, the value from the
completion will be used as-is in the query input field. For HTML-type
values it results in the HTML of the completion being injected in the
query input whenever a suggestion is selected, or highlighted via
keyboard controls, which obviously doesn't look very nice.

This change uses the underlying `value` of the completion instead which
is a simple string and will look nicer when injected in the query input.

This requires a change in the configuration: The `suggestion` template
needs to be updated to read the `disp` property of the completion rather
than the `value`, otherwise it will just display the value as-is rather
than the fancy HTML:

```javascript
template: {
  header: $('<h4>').text('Category name').addClass('tt-category'),
  suggestion: function(data) { return $('<span>').html(data.extra.disp); }
  notFound: $('<div>').html('<em>No suggestions found</em>')
}
```